### PR TITLE
Make HTML5 void elements self closing

### DIFF
--- a/lib/parse-tag.js
+++ b/lib/parse-tag.js
@@ -1,4 +1,5 @@
 var attrRE = /([\w-]+)|['"]{1}([^'"]*)['"]{1}/g;
+var voidElements = require('void-elements');
 
 
 module.exports = function (tag) {
@@ -18,6 +19,9 @@ module.exports = function (tag) {
         } else {
             if (i === 0) {
                 res.name = match;
+                if (voidElements.indexOf(match) !== -1) {
+                    res.selfClosing = true;
+                }
             } else {
                 res.attrs[key] = match.replace(/['"]/g, '');
             }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   },
   "scripts": {
     "test": "node test/index.js | tap-spec"
+  },
+  "dependencies": {
+    "void-elements": "^1.0.0"
   }
 }

--- a/test/parse-tag.js
+++ b/test/parse-tag.js
@@ -53,5 +53,15 @@ test('parseTag', function (t) {
         children: []
     });
 
+    tag = '<br>';
+
+    t.deepEqual(parseTag(tag), {
+        type: 'tag',
+        attrs: {},
+        name: 'br',
+        selfClosing: true,
+        children: []
+    });
+
     t.end();
 });


### PR DESCRIPTION
Not sure if this is a direction you want to go with the library, but this small change would make valid HTML5 parsable without changes. 
According to the spec void elements (http://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element) can never have content and are the only ones which can be self closing.