### PR TITLE
Fixes for parsing top-level and trailing text nodes.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -63,7 +63,10 @@ module.exports = function parse(html, options) {
             level--;
             if (!inComponent && nextChar !== '<' && nextChar) {
                 // trailing text node
-                arr[level].children.push({
+                // if we're at the root, push a base text node. otherwise add as
+                // a child to the current node.
+                parent = level === -1 ? result : arr[level].children;
+                parent.push({
                     type: 'text',
                     content: html.slice(start, html.indexOf('<', start))
                 });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -66,9 +66,14 @@ module.exports = function parse(html, options) {
                 // if we're at the root, push a base text node. otherwise add as
                 // a child to the current node.
                 parent = level === -1 ? result : arr[level].children;
+
+                // calculate correct end of the content slice in case there's
+                // no tag after the text node.
+                var end = html.indexOf('<', start);
+                end = end === -1 ? undefined : end;
                 parent.push({
                     type: 'text',
-                    content: html.slice(start, html.indexOf('<', start))
+                    content: html.slice(start, end)
                 });
             }
         }

--- a/test/parse.js
+++ b/test/parse.js
@@ -292,6 +292,65 @@ test('parse', function (t) {
             { type: 'text', content: ' 10 ' },
         ]
     }], 'should not give voidElements children');
+
+    html = '<div></div>\n';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        type: 'tag',
+        name: 'div',
+        attrs: {},
+        voidElement: false,
+        children: []
+    },{
+        type: 'text', content: '\n'
+    }], 'should not explode on trailing whitespace');
+
+    html = '<div>Hi</div> There ';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        type: 'tag',
+        name: 'div',
+        attrs: {},
+        voidElement: false,
+        children: [
+            { type: 'text', content: 'Hi' }
+        ]
+    },{
+        type: 'text', content: ' There '
+    }], 'should handle trailing text nodes at the top-level');
+
+    html = '<div>Hi</div> There <span>something</span> <a></a>else ';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        type: 'tag',
+        name: 'div',
+        attrs: {},
+        voidElement: false,
+        children: [
+            { type: 'text', content: 'Hi' }
+        ]
+    },{
+        type: 'text', content: ' There '
+    },{
+        type: 'tag',
+        name: 'span',
+        attrs: {},
+        voidElement: false,
+        children: [
+            { type: 'text', content: 'something' }
+        ]
+    },{
+        type: 'text', content: ' '
+    },{
+        type: 'tag',
+        name: 'a',
+        attrs: {},
+        voidElement: false,
+        children: []
+    },{
+        type: 'text', content: 'else '
+    }], 'should handle text nodes in the middle of tags at the top-level');
+
     t.end();
 });
 


### PR DESCRIPTION
Not sure if you guys are still active on this project at all, but here are some fixes for the `parse` function related to the top-level and trailing text nodes. Also fixes #3.

E.g.
```javascript
parse('<div></div> \n');
parse('<div></div> Something <span>else</span>'
```
doesn't explode the parser now, and instead it parses as expected.