### PR TITLE
Parse out attr values with quotation marks in them.

### DIFF
--- a/lib/parse-tag.js
+++ b/lib/parse-tag.js
@@ -1,7 +1,7 @@
-var attrRE = /([\w-]+)|['"]{1}([^'"]*)['"]{1}/g;
+var attrRE = /([\w-]+)|(['"])(.*?)\2/g;
 
 // create optimized lookup object for
-// void elements as listed here: 
+// void elements as listed here:
 // http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements
 var lookup = (Object.create) ? Object.create(null) : {};
 lookup.area = true;
@@ -42,7 +42,7 @@ module.exports = function (tag) {
                 }
                 res.name = match;
             } else {
-                res.attrs[key] = match.replace(/['"]/g, '');
+                res.attrs[key] = match.replace(/^['"]|['"]$/g, '');
             }
         }
         i++;

--- a/test/parse-tag.js
+++ b/test/parse-tag.js
@@ -53,5 +53,19 @@ test('parseTag', function (t) {
         children: []
     });
 
+    tag = '<div class="button another-button" onclick="do(\'something\');" onhover=\'do("something else")\'>';
+
+    t.deepEqual(parseTag(tag), {
+        type: 'tag',
+        attrs: {
+            class: 'button another-button',
+            onclick: 'do(\'something\');',
+            onhover: 'do("something else")'
+        },
+        name: 'div',
+        voidElement: false,
+        children: []
+    });
+
     t.end();
 });


### PR DESCRIPTION
Makes sure that we correctly parse attributes with quotation marks in them. For example inline event listeners:

``` html
<div onclick="alert('hi!')">Click me!</div>
```

The old regex didn't like that at all. The new one should effectively capture whatever is between `" "` or `' '` and use that as the attr value.
