### PR TITLE
MVP support of non-valued attributes in HTML5 tags

### DIFF
--- a/lib/parse-tag.js
+++ b/lib/parse-tag.js
@@ -32,21 +32,29 @@ module.exports = function (tag) {
         children: []
     };
 
-    tag.replace(attrRE, function (match) {
-        if (i % 2) {
-            key = match;
+    var matches = tag.match(attrRE);
+
+    var tagName = matches.shift();
+    if (lookup[tagName] || tag.charAt(tag.length - 2) === '/') {
+        res.voidElement = true;
+    }
+
+    matches.forEach((match, index) => {
+        if(!_isValue(match)) {
+            res.attrs[match] = "";
         } else {
-            if (i === 0) {
-                if (lookup[match] || tag.charAt(tag.length - 2) === '/') {
-                    res.voidElement = true;
-                }
-                res.name = match;
-            } else {
-                res.attrs[key] = match.replace(/['"]/g, '');
-            }
+            res.attrs[matches[index-1]] = match.replace(/['"]/g, '');
         }
-        i++;
     });
 
     return res;
 };
+
+
+function _isValue(potentialValue) {
+    if(potentialValue.indexOf('"') != -1 || potentialValue.indexOf("'") != -1) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/test/parse-tag.js
+++ b/test/parse-tag.js
@@ -53,5 +53,18 @@ test('parseTag', function (t) {
         children: []
     });
 
+    tag = '<something-custom non-valued-attribute valued-attribute=\'value\'>';
+
+    t.deepEqual(parseTag(tag), {
+        type: 'tag',
+        attrs: {
+            valued-attribute: 'value',
+            non-valued-attribute: ''
+        },
+        name: 'something-custom',
+        voidElement: false,
+        children: []
+    });
+
     t.end();
 });


### PR DESCRIPTION
- Allows to handle `<tag non-valued-custom-attribute valued-custom-attribute="some value" >` case properly.
- Test coverage with examplecase included.