### PR TITLE
Never allow for a level lower than -1

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+test
+.gitignore
+.jshintrc
+.jshintignore
+.travis.yml
+.zuul.yml

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -14,6 +14,14 @@ module.exports = function parse(html, options) {
     var byTag = {};
     var inComponent = false;
 
+    if (html.indexOf('<') !== 0) {
+        const end = html.indexOf('<');
+        result.push({
+            type: 'text',
+            content: end === -1 ? html : html.substring(0, end)
+        });
+    }
+
     html.replace(tagRE, function (tag, index) {
         if (inComponent) {
             if (tag !== ('</' + current.name + '>')) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -60,7 +60,10 @@ module.exports = function parse(html, options) {
         }
 
         if (!isOpen || current.voidElement) {
-            level--;
+            if (level > -1 && (current.voidElement || current.name === tag.slice(2, tag.indexOf(' ')))) {
+                level--;
+            }
+
             if (!inComponent && nextChar !== '<' && nextChar) {
                 // trailing text node
                 // if we're at the root, push a base text node. otherwise add as
@@ -79,6 +82,8 @@ module.exports = function parse(html, options) {
                     });
                 }
             }
+
+            current = arr[level];
         }
     });
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -15,7 +15,7 @@ module.exports = function parse(html, options) {
     var inComponent = false;
 
     if (html.indexOf('<') !== 0) {
-        const end = html.indexOf('<');
+        var end = html.indexOf('<');
         result.push({
             type: 'text',
             content: end === -1 ? html : html.substring(0, end)

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "html-parse-stringify",
+  "name": "@btpoe/html-parse-stringify",
   "description": "Parses well-formed HTML (meaning all tags closed) into an AST and back. quickly.",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "bugs": {
-    "url": "https://github.com/henrikjoreteg/html-parse-stringify/issues"
+    "url": "https://github.com/btpoe/html-parse-stringify/issues"
   },
   "dependencies": {
     "void-elements": "^1.0.0"
@@ -18,7 +18,7 @@
     "tape": "^3.0.3",
     "zuul": "^1.16.5"
   },
-  "homepage": "https://github.com/henrikjoreteg/html-parse-stringify",
+  "homepage": "https://github.com/btpoe/html-parse-stringify",
   "keywords": [
     "html",
     "parse",
@@ -29,7 +29,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/henrikjoreteg/html-parse-stringify"
+    "url": "https://github.com/btpoe/html-parse-stringify"
   },
   "scripts": {
     "start": "run-browser test/*",

--- a/test/parse.js
+++ b/test/parse.js
@@ -366,6 +366,42 @@ test('parse', function (t) {
             { type: 'text', content: 'There' }
         ]
     }], 'should remove text nodes that are nothing but whitespace');
+
+    html = '<div>Hi</span>There</div>';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        type: 'tag',
+        name: 'div',
+        attrs: {},
+        voidElement: false,
+        children: [
+            { type: 'text', content: 'Hi' },
+            { type: 'text', content: 'There' }
+        ]
+    }], 'should skip over closing tags that don\'t match the current tag name');
+
+    html = '<p>Hi There</p></span>root text</p><p>Try again</p>';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        type: 'tag',
+        name: 'p',
+        attrs: {},
+        voidElement: false,
+        children: [
+            { type: 'text', content: 'Hi There' }
+        ]
+    },{
+        type: 'text',
+        content: 'root text'
+    }, {
+        type: 'tag',
+        name: 'p',
+        attrs: {},
+        voidElement: false,
+        children: [
+            { type: 'text', content: 'Try again' }
+        ]
+    }], 'should not go lower than the root level (-1)');
     t.end();
 });
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -317,6 +317,27 @@ test('parse', function (t) {
         type: 'text', content: ' There '
     }], 'should handle trailing text nodes at the top-level');
 
+    html = 'Hi <div>There</div>';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        type: 'text', content: 'Hi '
+    }, {
+        type: 'tag',
+        name: 'div',
+        attrs: {},
+        voidElement: false,
+        children: [
+            { type: 'text', content: 'There' }
+        ]
+    }], 'should handle leading text nodes at the top-level');
+
+
+    html = 'Hi There';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        type: 'text', content: 'Hi There'
+    }], 'should handle plain strings of text with no tags');
+
     html = '<div>Hi</div> There <span>something</span> <a></a>else ';
     parsed = HTML.parse(html);
     t.deepEqual(parsed, [{


### PR DESCRIPTION
Ignore closing tags that don't match the current node.

I came across this issue from WYSIWYG generated markup that was including a closing tag to a `<wbr>`. The parser recognizes the tag as a void element and automatically closes it, so when it reaches the `</wbr>` it closes the parent element. The issue alerted me to a larger issue that is any closing tag will close out the current element, which isn't ideal.