### PR TITLE
Better Attr Parsing

### DIFF
--- a/lib/parse-tag.js
+++ b/lib/parse-tag.js
@@ -1,7 +1,7 @@
-var attrRE = /([\w-]+)|['"]{1}([^'"]*)['"]{1}/g;
+var attrRE = /\s([^'"/\s><]+?)[\s/>]|([^\s=]+)=\s?(".*?"|'.*?')/g
 
 // create optimized lookup object for
-// void elements as listed here: 
+// void elements as listed here:
 // http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements
 var lookup = (Object.create) ? Object.create(null) : {};
 lookup.area = true;
@@ -22,8 +22,6 @@ lookup.track = true;
 lookup.wbr = true;
 
 module.exports = function (tag) {
-    var i = 0;
-    var key;
     var res = {
         type: 'tag',
         name: '',
@@ -32,21 +30,41 @@ module.exports = function (tag) {
         children: []
     };
 
-    tag.replace(attrRE, function (match) {
-        if (i % 2) {
-            key = match;
-        } else {
-            if (i === 0) {
-                if (lookup[match] || tag.charAt(tag.length - 2) === '/') {
-                    res.voidElement = true;
-                }
-                res.name = match;
-            } else {
-                res.attrs[key] = match.replace(/['"]/g, '');
-            }
+    let tagMatch = tag.match(/<\/?([^\s]+?)[/\s>]/)
+    if(tagMatch)
+    {
+        res.name = tagMatch[1];
+        if (lookup[tagMatch[1].toLowerCase()] || tag.charAt(tag.length - 2) === '/')
+            res.voidElement = true;
+
+    }
+
+    let reg = new RegExp(attrRE)
+    let result = null;
+    for (; ;)
+    {
+        result = reg.exec(tag);
+
+        if (result === null)
+            break;
+
+        if (!result[0].trim())
+            continue;
+
+        if (result[1])
+        {
+            let attr = result[1].trim();
+            let arr = [attr, ""];
+
+            if(attr.indexOf("=") > -1)
+                arr = attr.split("=");
+
+            res.attrs[arr[0]] = arr[1];
+            reg.lastIndex--;
         }
-        i++;
-    });
+        else if (result[2])
+            res.attrs[result[2]] = result[3].trim().substring(1,result[3].length - 1);
+    }
 
     return res;
 };

--- a/test/parse-tag.js
+++ b/test/parse-tag.js
@@ -53,5 +53,22 @@ test('parseTag', function (t) {
         children: []
     });
 
+    tag = '<svg aria-hidden="true" style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-id="175">'
+
+    t.deepEqual(parseTag(tag), {
+        type: 'tag', 
+        name: 'svg', 
+        attrs: { 
+            'aria-hidden': 'true', 
+            'data-id': '175', 
+            style: 'position: absolute; width: 0; height: 0; overflow: hidden;', 
+            version: '1.1', 
+            xmlns: 'http://www.w3.org/2000/svg', 
+            'xmlns:xlink': 'http://www.w3.org/1999/xlink' 
+        },
+        voidElement: false,
+        children: []
+    }, 'should parse tags containing attributes with hyphens and/or colons');
+
     t.end();
 });


### PR DESCRIPTION
Boasting a [major performance gain](https://jsbench.me/gtjyyxihw9) this PR also allows opposite quotes inside of attributes ("'something'" or '"something"') and [Boolean attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes).

This is a more thorough solution to the problems presented in #13 and #19. 