### PR TITLE
Parse and stringify comments

### DIFF
--- a/lib/parse-tag.js
+++ b/lib/parse-tag.js
@@ -38,6 +38,18 @@ module.exports = function (tag) {
             res.voidElement = true;
         }
 
+        if (res.name === '!--') { // comment tag
+            res = {
+                type: 'comment',
+            };
+            res.comment = '';
+            var end = tag.indexOf('-->');
+            if (end !== -1) {
+                var comment = tag.slice(4, end);
+                res.comment = comment;
+            }
+            return res;
+        }
     }
 
     var reg = new RegExp(attrRE);

--- a/lib/parse-tag.js
+++ b/lib/parse-tag.js
@@ -38,7 +38,7 @@ module.exports = function (tag) {
             res.voidElement = true;
         }
 
-        if (res.name === '!--') { // comment tag
+        if (res.name.startsWith('!--')) { // comment tag
             res = {
                 type: 'comment',
             };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -12,7 +12,6 @@ module.exports = function parse(html, options) {
     var current;
     var level = -1;
     var arr = [];
-    var byTag = {};
     var inComponent = false;
 
     html.replace(tagRE, function (tag, index) {
@@ -43,8 +42,6 @@ module.exports = function parse(html, options) {
                     content: html.slice(start, html.indexOf('<', start))
                 });
             }
-
-            byTag[current.tagName] = current;
 
             // if we're at root, push new base node
             if (level === 0) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -23,9 +23,23 @@ module.exports = function parse(html, options) {
             }
         }
         var isOpen = tag.charAt(1) !== '/';
+        var isComment = tag.startsWith('<!--');
         var start = index + tag.length;
         var nextChar = html.charAt(start);
         var parent;
+
+        if (isComment) {
+            var comment = parseTag(tag)
+
+            // if we're at root, push new base node
+            if (level < 0) {
+                result.push(comment);
+                return result
+            }
+            parent = arr[level]
+            parent.children.push(comment)
+            return result
+        }
 
         if (isOpen) {
             level++;

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -19,6 +19,9 @@ function stringify(buff, doc) {
             return buff;
         }
         return buff + doc.children.reduce(stringify, '') + '</' + doc.name + '>';
+    case 'comment':
+        buff += '<!--' + doc.comment + '-->';
+        return buff;
     }
 }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -84,6 +84,53 @@ test('parse', function (t) {
     }]);
     t.equal(html, HTML.stringify(parsed));
 
+    html = '<div><h2>Comment below this header</h2><!-- just a comment node --><!-- subsequent comment node --></div>';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        name: 'div',
+        type: 'tag',
+        attrs: {},
+        voidElement: false,
+        children: [{
+            attrs: {},
+            name: 'h2',
+            type: 'tag',
+            voidElement: false,
+            children: [{
+                content: 'Comment below this header',
+                type: 'text'
+            }]
+        },
+        {
+            type: 'comment' ,
+            comment: ' just a comment node ',
+        },{
+            type: 'comment',
+            comment: ' subsequent comment node '
+        }]
+    }]);
+    t.equal(html, HTML.stringify(parsed));
+
+    html = '<div><h2><!-- comment inside h2 tag --></h2></div>';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        name: 'div',
+        type: 'tag',
+        attrs: {},
+        voidElement: false,
+        children: [{
+            attrs: {},
+            name: 'h2',
+            type: 'tag',
+            voidElement: false,
+            children: [{
+                type: 'comment' ,
+                comment: ' comment inside h2 tag ',
+            }]
+        }]
+    }]);
+    t.equal(html, HTML.stringify(parsed));
+
     html = '<!---->'
     parsed = HTML.parse(html);
     t.deepEqual(parsed, [{

--- a/test/parse.js
+++ b/test/parse.js
@@ -52,6 +52,39 @@ test('parse', function (t) {
     }]);
     t.equal(html, HTML.stringify(parsed));
 
+    html = '<!-- just a comment node -->';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+      type: 'comment',
+      comment: ' just a comment node '
+    }]);
+    t.equal(html, HTML.stringify(parsed));
+
+    html = '<div><h2>Comment below this header</h2><!-- just a comment node --></div>';
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+        name: 'div',
+        type: 'tag',
+        attrs: {},
+        voidElement: false,
+        children: [{
+            attrs: {},
+            name: 'h2',
+            type: 'tag',
+            voidElement: false,
+            children: [{
+                content: 'Comment below this header',
+                type: 'text'
+            }]
+        },
+        {
+            type: 'comment' ,
+            comment: ' just a comment node ',
+        }]
+    }]);
+    t.equal(html, HTML.stringify(parsed));
+
+
     html = '<div>oh <strong>hello</strong> there! How are <span>you</span>?</div>';
     parsed = HTML.parse(html);
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -84,6 +84,21 @@ test('parse', function (t) {
     }]);
     t.equal(html, HTML.stringify(parsed));
 
+    html = '<!---->'
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+      type: 'comment',
+      comment: ''
+    }]);
+    t.equal(html, HTML.stringify(parsed));
+
+    html = '<!---this comment starts with a hyphen b/c web developers love curveballs -->'
+    parsed = HTML.parse(html);
+    t.deepEqual(parsed, [{
+      type: 'comment',
+      comment: '-this comment starts with a hyphen b/c web developers love curveballs '
+    }]);
+    t.equal(html, HTML.stringify(parsed));
 
     html = '<div>oh <strong>hello</strong> there! How are <span>you</span>?</div>';
     parsed = HTML.parse(html);


### PR DESCRIPTION
Currently html-parse-stringify is badly stringifying comments, turning:
```
<!-- something like this -->
```
into something like this:
```
<!-- something="" like="" this="" --=""><!--/>
```

so this PR fixes it, by creating a new parsed node type with a custom output rule. 

review would be great @kranges !