### PR TITLE
Fixes #40

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -90,6 +90,8 @@ export default function parse(html, options) {
         (current.voidElement || current.name === tag.slice(2, -1))
       ) {
         level--
+        // move current up a level to match the end tag
+        current = level === -1 ? result : arr[level]
       }
       if (!inComponent && nextChar !== '<' && nextChar) {
         // trailing text node

--- a/test/parse.js
+++ b/test/parse.js
@@ -55,6 +55,54 @@ test('parse', function (t) {
   ])
   t.equal(html, HTML.stringify(parsed))
 
+  html = '<div class="oh"><p><span>hi</span></p><p>bye</p></div>'
+  parsed = HTML.parse(html)
+  t.deepEqual(parsed, [
+    {
+      type: 'tag',
+      name: 'div',
+      attrs: {
+        class: 'oh',
+      },
+      voidElement: false,
+      children: [
+        {
+          type: 'tag',
+          name: 'p',
+          attrs: {},
+          voidElement: false,
+          children: [
+            {
+              type: 'tag',
+              name: 'span',
+              attrs: {},
+              voidElement: false,
+              children: [
+                {
+                  type: 'text',
+                  content: 'hi',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'tag',
+          name: 'p',
+          attrs: {},
+          voidElement: false,
+          children: [
+            {
+              type: 'text',
+              content: 'bye',
+            },
+          ],
+        },
+      ],
+    },
+  ])
+  t.equal(html, HTML.stringify(parsed))
+
   html = '<!-- just a comment node -->'
   parsed = HTML.parse(html)
   t.deepEqual(parsed, [


### PR DESCRIPTION
In 2.0.0 there was a change to make sure the end tag match the `current` tag before decrementing the level. However, the `current` tag did not move up a level after closing. This resulted in the next sibling ending up as a child.