### PR TITLE
Support numeric tags

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -1,4 +1,4 @@
-const tagRE = /<[a-zA-Z\-\!\/](?:"[^"]*"|'[^']*'|[^'">])*>/g
+const tagRE = /<[a-zA-Z0-9\-\!\/](?:"[^"]*"|'[^']*'|[^'">])*>/g
 import parseTag from './parse-tag'
 
 // re-used obj for quick lookups of components

--- a/test/parse.js
+++ b/test/parse.js
@@ -230,6 +230,57 @@ test('parse', function (t) {
   ])
   t.equal(html, HTML.stringify(parsed))
 
+  html = '<0>oh <1>hello</1> there! How are <2>you</2>?</0>'
+  parsed = HTML.parse(html)
+
+  t.deepEqual(parsed, [
+    {
+      type: 'tag',
+      name: '0',
+      attrs: {},
+      voidElement: false,
+      children: [
+        {
+          type: 'text',
+          content: 'oh ',
+        },
+        {
+          type: 'tag',
+          name: '1',
+          attrs: {},
+          voidElement: false,
+          children: [
+            {
+              type: 'text',
+              content: 'hello',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          content: ' there! How are ',
+        },
+        {
+          type: 'tag',
+          name: '2',
+          attrs: {},
+          voidElement: false,
+          children: [
+            {
+              type: 'text',
+              content: 'you',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          content: '?',
+        },
+      ],
+    },
+  ])
+  t.equal(html, HTML.stringify(parsed))
+
   html = '<div class="handles multiple classes" and="attributes"></div>'
   parsed = HTML.parse(html)
 


### PR DESCRIPTION
This PR adds support for tags like `<0>hello <1>world</1></0>`.

With this feature supported, [react-i18next](https://github.com/i18next/react-i18next) can potentially switch back from [`html-parse-stringify2`](https://github.com/rayd/html-parse-stringify2) to `html-parse-stringify`.

Context:

- https://github.com/i18next/react-i18next/issues/1275
- https://github.com/i18next/react-i18next/pull/1283