### PR TITLE
Add broken tests for multiple nested tags

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -90,6 +90,7 @@ export default function parse(html, options) {
         (current.voidElement || current.name === tag.slice(2, -1))
       ) {
         level--
+        current = level === -1 ? result : arr[level]
       }
       if (!inComponent && nextChar !== '<' && nextChar) {
         // trailing text node

--- a/test/parse.js
+++ b/test/parse.js
@@ -230,6 +230,53 @@ test('parse', function (t) {
   ])
   t.equal(html, HTML.stringify(parsed))
 
+  html = '<div>Testing <strong>multiple <em>nested</em></strong> tags</div>'
+  parsed = HTML.parse(html)
+
+  t.deepEqual(parsed, [
+    {
+      type: 'tag',
+      name: 'div',
+      attrs: {},
+      voidElement: false,
+      children: [
+        {
+          type: 'text',
+          content: 'Testing ',
+        },
+        {
+          type: 'tag',
+          name: 'strong',
+          attrs: {},
+          voidElement: false,
+          children: [
+            {
+              type: 'text',
+              content: 'multiple ',
+            },
+            {
+              type: 'tag',
+              name: 'em',
+              attrs: {},
+              voidElement: false,
+              children: [
+                {
+                  type: 'text',
+                  content: 'nested',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'text',
+          content: ' tags',
+        },
+      ],
+    },
+  ])
+  t.equal(html, HTML.stringify(parsed))
+
   html = '<div class="handles multiple classes" and="attributes"></div>'
   parsed = HTML.parse(html)
 


### PR DESCRIPTION
When self-encoding

```html
<div>Testing <strong>multiple <em>nested</em></strong> tags</div>
```

the result is unexpectedly

```html
<div>Testing <strong>multiple <em>nested</em> tags</strong></div>
```

This can be related to https://github.com/HenrikJoreteg/html-parse-stringify/issues/40

Fixing this issue in addition to #43 can unblock https://github.com/i18next/react-i18next/pull/1283

[`next-i18next`](https://www.npmjs.com/package/react-i18next) has ≈1M weekly downloads from npm, which can give this library quite a boost in its popularity!