### PR TITLE
checking void elements should be case sensitive

### DIFF
--- a/src/parse-tag.js
+++ b/src/parse-tag.js
@@ -14,7 +14,7 @@ export default function stringify(tag) {
   if (tagMatch) {
     res.name = tagMatch[1]
     if (
-      lookup[tagMatch[1].toLowerCase()] ||
+      lookup[tagMatch[1]] ||
       tag.charAt(tag.length - 2) === '/'
     ) {
       res.voidElement = true

--- a/test/parse.js
+++ b/test/parse.js
@@ -936,3 +936,39 @@ test('whitespace', function (t) {
 
   t.end()
 })
+
+test('uppercase tags', function (t) {
+  const html = '<0>click <Link>here</Link> for more</0>'
+  const parsed = HTML.parse(html)
+  t.deepEqual(parsed, [
+    {
+      "type": "tag",
+      "name": "0",
+      "voidElement": false,
+      "attrs": {},
+      "children": [
+        {
+          "type": "text",
+          "content": "click "
+        },
+        {
+          "type": "tag",
+          "name": "Link",
+          "voidElement": false,
+          "attrs": {},
+          "children": [
+            {
+              "type": "text",
+              "content": "here"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "content": " for more"
+        }
+      ]
+    }
+  ], 'should handle uppercase tags correctly')
+  t.end()
+})


### PR DESCRIPTION
Fixes a regression in react-i18next: https://github.com/i18next/react-i18next/issues/1304

Seems the `.toLowerCase()` change was introduced unintentionally here: https://github.com/HenrikJoreteg/html-parse-stringify/pull/28/commits/ffb47bb05ae4fb4949ff37effc8dd79e81cd9b1d#diff-ef2f58723392c7c71346a734e4826c4816aa3e276b95a7d8dc6349939775628cR37 by @kranges
