### PR TITLE
3.1.0: long-standing community fixes + release prep

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Henrik Joreteg <henrik@joreteg.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # html-parse-stringify
 
+> **Note:** development of this package continues at [i18next/html-parse-stringify](https://github.com/i18next/html-parse-stringify), where version 4.x and later are maintained. 3.1.0 is the final release from this repository; the npm package name stays `html-parse-stringify`. See [issue #65](https://github.com/HenrikJoreteg/html-parse-stringify/issues/65) for the background.
+
 This is an _experimental lightweight approach_ to enable quickly parsing HTML into an AST and stringify'ing it back to the original string.
 
 As it turns out, if you can make a the simplifying assumptions about HTML that all tags must be closed or self-closing. Which is OK for _this_ particular application. You can write a super light/fast parser in JS with regex.
@@ -135,6 +137,7 @@ properties:
 
 ## changelog
 
+- `3.1.0` Maintenance release, merging long-standing community PRs: LICENSE file shipped in the npm package (#66 by @monholm, closes #61), text containing `<` no longer truncated (#64, closes #59), multi-line attribute values (#63 by @steffanhalv, closes #62), TypeScript declaration shipped and improved (#51/#52 by @jiangfengming, closes #56), text after comment nodes no longer discarded (#53 by @tohosaku). Development continues at [i18next/html-parse-stringify](https://github.com/i18next/html-parse-stringify).
 - `3.0.1` Merged #47 which makes void elements check case insensitive. Thanks again, [@adrai](https://github.com/adrai) for this contribution!
 - `3.0.0` Merged #46 which fixed an issue with handling of whitespace. Doing major version bump since this changes behavior if you have whitespace only nodes (see merged PR and #45 for more details). Thanks [@adrai](https://github.com/adrai) for this contribution!
 - `2.1.1` Merged #41 which fixed an issue with tag nesting. Thanks [@ericponto](https://github.com/ericponto).

--- a/html-parse-stringify.d.ts
+++ b/html-parse-stringify.d.ts
@@ -1,27 +1,35 @@
-declare var htmlParseStringify: htmlParseStringify.htmlParseStringify
-
-declare module htmlParseStringify {
-  export interface htmlParseStringify {
-    new (): htmlParseStringify
-    parse_tag(tag: string): IDoc
-    parse(html: string, options?: IOptions): Array<any>
-    stringify(doc: IDoc): string
-  }
-
-  export interface IDoc {
-    type: string
-    content?: string
-    voidElement: boolean
-    name: string
-    attrs: Record<string, string>
-    children: IDoc[]
-  }
-
-  export interface IOptions {
-    components: string[]
-  }
-}
-
 declare module 'html-parse-stringify' {
-  export = htmlParseStringify
+  export interface TagNode {
+    type: 'tag';
+    name: string;
+    voidElement: boolean;
+    attrs: Record<string, string | undefined>;
+    children: Node[];
+  }
+
+  export interface TextNode {
+    type: 'text';
+    content: string;
+  }
+
+  export interface ComponentNode {
+    type: 'component';
+    name: string;
+    attrs: Record<string, string | undefined>;
+    voidElement: boolean;
+    children: [];
+  }
+
+  export type Node = TagNode | TextNode | ComponentNode;
+
+  export interface ParseOptions {
+    components: Record<string, boolean>;
+  }
+
+  namespace HtmlParseStringify {
+    function parse(html: string, options?: ParseOptions): Node[];
+    function stringify(doc: Node[]): string;
+  }
+
+  export default HtmlParseStringify;
 }

--- a/html-parse-stringify.d.ts
+++ b/html-parse-stringify.d.ts
@@ -4,7 +4,7 @@ declare module htmlParseStringify {
   export interface htmlParseStringify {
     new (): htmlParseStringify
     parse_tag(tag: string): IDoc
-    parse(html: string, options: IOptions): Array<any>
+    parse(html: string, options?: IOptions): Array<any>
     stringify(doc: IDoc): string
   }
 
@@ -13,7 +13,7 @@ declare module htmlParseStringify {
     content?: string
     voidElement: boolean
     name: string
-    attrs: {}
+    attrs: Record<string, string>
     children: IDoc[]
   }
 

--- a/html-parse-stringify.d.ts
+++ b/html-parse-stringify.d.ts
@@ -1,35 +1,43 @@
 declare module 'html-parse-stringify' {
-  export interface TagNode {
-    type: 'tag';
-    name: string;
-    voidElement: boolean;
-    attrs: Record<string, string | undefined>;
-    children: Node[];
-  }
+  namespace HTML {
+    interface TagNode {
+      type: 'tag';
+      name: string;
+      voidElement: boolean;
+      attrs: Record<string, string | undefined>;
+      children: Node[];
+    }
 
-  export interface TextNode {
-    type: 'text';
-    content: string;
-  }
+    interface TextNode {
+      type: 'text';
+      content: string;
+    }
 
-  export interface ComponentNode {
-    type: 'component';
-    name: string;
-    attrs: Record<string, string | undefined>;
-    voidElement: boolean;
-    children: [];
-  }
+    interface CommentNode {
+      type: 'comment';
+      comment: string;
+    }
 
-  export type Node = TagNode | TextNode | ComponentNode;
+    interface ComponentNode {
+      type: 'component';
+      name: string;
+      attrs: Record<string, string | undefined>;
+      voidElement: boolean;
+      children: [];
+    }
 
-  export interface ParseOptions {
-    components: Record<string, boolean>;
-  }
+    type Node = TagNode | TextNode | CommentNode | ComponentNode;
 
-  namespace HtmlParseStringify {
+    interface ParseOptions {
+      components?: Record<string, boolean>;
+    }
+
     function parse(html: string, options?: ParseOptions): Node[];
     function stringify(doc: Node[]): string;
   }
 
-  export default HtmlParseStringify;
+  // the CommonJS build assigns `module.exports = { parse, stringify }` with
+  // no `default` property, so `export =` is the only declaration shape that
+  // is correct both with and without esModuleInterop
+  export = HTML;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "html-parse-stringify",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "tape": "5.0.1"
   },
   "files": [
-    "dist"
+    "dist",
+    "html-parse-stringify.d.ts"
   ],
   "homepage": "https://github.com/henrikjoreteg/html-parse-stringify",
   "keywords": [
@@ -31,6 +32,7 @@
   "module": "dist/html-parse-stringify.module.js",
   "source": "src/index.js",
   "unpkg": "dist/html-parse-stringify.umd.js",
+  "types": "html-parse-stringify.d.ts",
   "prettier": {
     "arrowParens": "avoid",
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "html-parse-stringify",
   "description": "Parses well-formed HTML (meaning all tags closed) into an AST and back. quickly.",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "author": "Henrik Joreteg <henrik@joreteg.com>",
   "bugs": {
     "url": "https://github.com/henrikjoreteg/html-parse-stringify/issues"

--- a/src/parse-tag.js
+++ b/src/parse-tag.js
@@ -1,5 +1,5 @@
 import lookup from 'void-elements'
-const attrRE = /\s([^'"/\s><]+?)[\s/>]|([^\s=]+)=\s?(".*?"|'.*?')/g
+const attrRE = /\s([^'"/\s><]+?)[\s/>]|([^\s=]+)=\s?("(.|\n)*?"|'(.|\n)*?')/g
 
 export default function stringify(tag) {
   const res = {

--- a/src/parse-tag.js
+++ b/src/parse-tag.js
@@ -13,10 +13,7 @@ export default function stringify(tag) {
   const tagMatch = tag.match(/<\/?([^\s]+?)[/\s>]/)
   if (tagMatch) {
     res.name = tagMatch[1]
-    if (
-      lookup[tagMatch[1]] ||
-      tag.charAt(tag.length - 2) === '/'
-    ) {
+    if (lookup[tagMatch[1]] || tag.charAt(tag.length - 2) === '/') {
       res.voidElement = true
     }
 

--- a/src/parse-tag.js
+++ b/src/parse-tag.js
@@ -1,5 +1,5 @@
 import lookup from 'void-elements'
-const attrRE = /\s([^'"/\s><]+?)[\s/>]|([^\s=]+)=\s?("(.|\n)*?"|'(.|\n)*?')/g
+const attrRE = /\s([^'"/\s><]+?)[\s/>]|([^\s=]+)=\s?("[^"]*"|'[^']*')/g
 
 export default function stringify(tag) {
   const res = {

--- a/src/parse.js
+++ b/src/parse.js
@@ -48,6 +48,14 @@ export default function parse(html, options) {
       }
       parent = arr[level]
       parent.children.push(comment)
+
+      const text = html.slice(start, html.indexOf('<', start));
+      if (text.length > 0) {
+        parent.children.push({
+          type: 'text',
+          content: text
+        })
+      }
       return result
     }
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -96,7 +96,7 @@ export default function parse(html, options) {
       parent = arr[level]
       parent.children.push(comment)
 
-      const text = html.slice(start, html.indexOf('<', start))
+      const text = html.slice(start, nextMatch ? nextMatch.index : undefined)
       if (text.length > 0) {
         parent.children.push({
           type: 'text',
@@ -121,21 +121,11 @@ export default function parse(html, options) {
         nextChar &&
         nextChar !== '<'
       ) {
-        let possibleContent = html.slice(start, html.indexOf('<', start))
-        const indexOfPossibleContent = html.indexOf(possibleContent, start)
-        const startAfterPossibleContent =
-          indexOfPossibleContent + possibleContent.length + 1
-        const nextLt = html.indexOf('<', startAfterPossibleContent)
-        const nextGt = html.indexOf('>', startAfterPossibleContent)
-        if (nextLt > -1 && nextLt < nextGt) {
-          possibleContent = html.slice(
-            start,
-            html.indexOf('<', startAfterPossibleContent)
-          )
-        }
+        // text content runs to the next actual tag match; stray `<`
+        // characters in between are part of the text
         current.children.push({
           type: 'text',
-          content: possibleContent,
+          content: html.slice(start, nextMatch ? nextMatch.index : undefined),
         })
       }
 
@@ -168,13 +158,9 @@ export default function parse(html, options) {
         // a child to the current node.
         parent = level === -1 ? result : arr[level].children
 
-        // calculate correct end of the content slice in case there's
-        // no tag after the text node.
-        let end = html.indexOf('<', start)
-        if (isText) {
-          const nextTag = html.substring(nextMatch.index)
-          end = html.indexOf(nextTag, start)
-        }
+        // the text node runs to the next actual tag match; -1 means
+        // there's no tag after it (trailing text)
+        const end = nextMatch ? nextMatch.index : -1
         let content = html.slice(start, end === -1 ? undefined : end)
         // if a node is nothing but whitespace, collapse it as the spec states:
         // https://www.w3.org/TR/html4/struct/text.html#h-9.1

--- a/src/parse.js
+++ b/src/parse.js
@@ -54,7 +54,12 @@ export default function parse(html, options) {
         gts++
       }
     }
-    if (lts > gts && secondLt > -1) {
+    // only split when the remainder is itself a valid tag start; otherwise
+    // a fragment like `< <!-->` desyncs the string-level isComment check
+    // from parseTag's name-based comment detection and crashes the walker
+    const validSplit =
+      secondLt > -1 && /[a-zA-Z0-9\-!/]/.test(tag.charAt(secondLt + 1))
+    if (lts > gts && validSplit) {
       const firstPart = tag.substring(0, secondLt)
       const secondPart = tag.substring(firstPart.length)
       matches[i][0] = secondPart

--- a/src/parse.js
+++ b/src/parse.js
@@ -33,10 +33,29 @@ export default function parse(html, options) {
   matches.forEach(function (match, i) {
     const tag = match[0]
     if (!tag) return
-    const amountOfLts = tag.split('<').length
-    const amountOfGts = tag.split('>').length
-    if (amountOfLts > 0 && amountOfLts > amountOfGts) {
-      const firstPart = tag.substring(0, tag.indexOf('<', tag.indexOf('<') + 1))
+    // comments are handled by parseTag as a whole
+    if (tag.startsWith('<!--')) return
+    // count brackets outside quoted attribute values, so `<` inside an
+    // attribute (e.g. title="1 < 2") can't trigger a bogus split
+    let lts = 0
+    let gts = 0
+    let secondLt = -1
+    let quote = null
+    for (let j = 0; j < tag.length; j++) {
+      const c = tag.charAt(j)
+      if (quote) {
+        if (c === quote) quote = null
+      } else if (c === '"' || c === "'") {
+        quote = c
+      } else if (c === '<') {
+        lts++
+        if (lts === 2) secondLt = j
+      } else if (c === '>') {
+        gts++
+      }
+    }
+    if (lts > gts && secondLt > -1) {
+      const firstPart = tag.substring(0, secondLt)
       const secondPart = tag.substring(firstPart.length)
       matches[i][0] = secondPart
       matches[i].index += firstPart.length

--- a/src/parse.js
+++ b/src/parse.js
@@ -24,10 +24,15 @@ export default function parse(html, options) {
     })
   }
 
-  const matches = Array.from(html.matchAll(tagRE))
+  // collect matches with an exec loop instead of matchAll to keep ES5 API compat
+  const matches = []
+  let m
+  while ((m = tagRE.exec(html))) {
+    matches.push(m)
+  }
   matches.forEach(function (match, i) {
     const tag = match[0]
-    if (!tag) return console.log({ html, matches })
+    if (!tag) return
     const amountOfLts = tag.split('<').length
     const amountOfGts = tag.split('>').length
     if (amountOfLts > 0 && amountOfLts > amountOfGts) {
@@ -54,11 +59,11 @@ export default function parse(html, options) {
     const nextChar = html.charAt(start)
     const nextMatch = matches[i + 1]
     let isText
-    if (nextChar === '<' && nextMatch)  {
+    if (nextChar === '<' && nextMatch) {
       const nextTag = html.substring(start, nextMatch.index)
-      isText = nextTag.split('<').length >  nextTag.split('>').length
+      isText = nextTag.split('<').length > nextTag.split('>').length
     }
-    
+
     let parent
 
     if (isComment) {
@@ -72,11 +77,11 @@ export default function parse(html, options) {
       parent = arr[level]
       parent.children.push(comment)
 
-      const text = html.slice(start, html.indexOf('<', start));
+      const text = html.slice(start, html.indexOf('<', start))
       if (text.length > 0) {
         parent.children.push({
           type: 'text',
-          content: text
+          content: text,
         })
       }
       return result
@@ -99,11 +104,15 @@ export default function parse(html, options) {
       ) {
         let possibleContent = html.slice(start, html.indexOf('<', start))
         const indexOfPossibleContent = html.indexOf(possibleContent, start)
-        const startAfterPossibleContent = indexOfPossibleContent + possibleContent.length + 1
+        const startAfterPossibleContent =
+          indexOfPossibleContent + possibleContent.length + 1
         const nextLt = html.indexOf('<', startAfterPossibleContent)
         const nextGt = html.indexOf('>', startAfterPossibleContent)
         if (nextLt > -1 && nextLt < nextGt) {
-          possibleContent = html.slice(start, html.indexOf('<', startAfterPossibleContent))
+          possibleContent = html.slice(
+            start,
+            html.indexOf('<', startAfterPossibleContent)
+          )
         }
         current.children.push({
           type: 'text',

--- a/test/parse.js
+++ b/test/parse.js
@@ -724,7 +724,7 @@ test('parse', function (t) {
         children: [
           {
             content:
-              "\n      !function() {\n        var cookies = document.cookie ? document.cookie.split(';') : [];\n        //                |   this less than is triggering probems\n        for (var i = 0; i ",
+              "\n      !function() {\n        var cookies = document.cookie ? document.cookie.split(';') : [];\n        //                |   this less than is triggering probems\n        for (var i = 0; i < cookies.length; i++) {\n          var splitted = cookies[i].split(\'=\');\n          var name = splitted[0];\n        }\n      }();\n      ",
             type: 'text',
           },
         ],
@@ -966,6 +966,83 @@ test('uppercase tags', function (t) {
         {
           "type": "text",
           "content": " for more"
+        }
+      ]
+    }
+  ], 'should handle uppercase tags correctly')
+  t.end()
+})
+
+test('open tag in html string', function (t) {
+  const html = '<0>hello under <10 <div>under 10</div> ok?</0>'
+  const parsed = HTML.parse(html)
+  t.deepEqual(parsed, [
+    {
+      "type": "tag",
+      "name": "0",
+      "voidElement": false,
+      "attrs": {},
+      "children": [
+        {
+          "type": "text",
+          "content": "hello under <10 "
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {},
+          "children": [
+            {
+              "type": "text",
+              "content": "under 10"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "content": " ok?"
+        }
+      ]
+    }
+  ], 'should handle uppercase tags correctly')
+  t.end()
+})
+
+
+test('open tag in html string complex', function (t) {
+  const html = 'hello <italic>under ten</italic><10 this text after the sign should be rendered<bold>END</bold>'
+  const parsed = HTML.parse(html)
+  t.deepEqual(parsed, [
+    {
+      "type": "text",
+      "content": "hello "
+    },
+    {
+      "type": "tag",
+      "name": "italic",
+      "voidElement": false,
+      "attrs": {},
+      "children": [
+        {
+          "type": "text",
+          "content": "under ten"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "content": "<10 this text after the sign should be rendered"
+    },
+    {
+      "type": "tag",
+      "name": "bold",
+      "voidElement": false,
+      "attrs": {},
+      "children": [
+        {
+          "type": "text",
+          "content": "END"
         }
       ]
     }

--- a/test/parse.js
+++ b/test/parse.js
@@ -238,6 +238,7 @@ test('parse', function (t) {
       children: [
         { type: "text", content: " " },
         { type: "comment", comment: " First comment " },
+        { type: "text", content: " " },
         {
           type: "tag",
           name: "span",

--- a/test/parse.js
+++ b/test/parse.js
@@ -227,6 +227,31 @@ test('parse', function (t) {
   ])
   t.equal(html, HTML.stringify(parsed))
 
+  html = '<div> <!-- First comment --> <span>Hi</span> <!-- Another comment --> Something</div>'
+  parsed = HTML.parse(html)
+  t.deepEqual(parsed, [
+    {
+      type: "tag",
+      name: "div",
+      voidElement: false,
+      attrs: {},
+      children: [
+        { type: "text", content: " " },
+        { type: "comment", comment: " First comment " },
+        {
+          type: "tag",
+          name: "span",
+          voidElement: false,
+          attrs: {},
+          children: [{ type: "text", content: "Hi" }],
+        },
+        { type: "text", content: " " },
+        { type: "comment", comment: " Another comment " },
+        { type: "text", content: " Something" },
+      ],
+    }
+  ])
+
   html = '<div>oh <strong>hello</strong> there! How are <span>you</span>?</div>'
   parsed = HTML.parse(html)
 
@@ -850,7 +875,7 @@ test('simple speed sanity check', function (t) {
       total += stepAverage
       waitCount = waitLoopSize
       // forcing a bit of a pause between tests
-      while (waitCount--) {}
+      while (waitCount--) { }
     }
   }
 
@@ -908,7 +933,7 @@ test('whitespace', function (t) {
     children: [
       { type: 'text', content: 'Hi' }
     ]
-  },{
+  }, {
     type: 'text',
     content: ' '
   },
@@ -920,10 +945,10 @@ test('whitespace', function (t) {
     children: [
       { type: 'text', content: 'There' }
     ]
-  },{
+  }, {
     type: 'text',
     content: ' '
-  },{
+  }, {
     type: 'tag',
     name: 'div',
     attrs: {},

--- a/test/parse.js
+++ b/test/parse.js
@@ -1183,3 +1183,18 @@ test('multiple literal < in text and CRLF attributes (#67 review round 2)', func
   )
   t.end()
 })
+
+test('pathological split fragments must not crash (#67 fuzz)', function (t) {
+  // the mismatched-bracket split used to produce fragments that parseTag
+  // saw as comments while the walker treated them as open tags
+  t.doesNotThrow(function () {
+    HTML.parse("<a< <!-->'")
+  }, 'split fragment parsing as comment')
+  t.doesNotThrow(function () {
+    HTML.parse("</0><3 a < b <!-- c -->=<div -->'")
+  }, 'fuzzer-found crash input')
+  t.doesNotThrow(function () {
+    HTML.parse('<div>a<b<c<d</div>')
+  }, 'chained stray < runs')
+  t.end()
+})

--- a/test/parse.js
+++ b/test/parse.js
@@ -227,30 +227,31 @@ test('parse', function (t) {
   ])
   t.equal(html, HTML.stringify(parsed))
 
-  html = '<div> <!-- First comment --> <span>Hi</span> <!-- Another comment --> Something</div>'
+  html =
+    '<div> <!-- First comment --> <span>Hi</span> <!-- Another comment --> Something</div>'
   parsed = HTML.parse(html)
   t.deepEqual(parsed, [
     {
-      type: "tag",
-      name: "div",
+      type: 'tag',
+      name: 'div',
       voidElement: false,
       attrs: {},
       children: [
-        { type: "text", content: " " },
-        { type: "comment", comment: " First comment " },
-        { type: "text", content: " " },
+        { type: 'text', content: ' ' },
+        { type: 'comment', comment: ' First comment ' },
+        { type: 'text', content: ' ' },
         {
-          type: "tag",
-          name: "span",
+          type: 'tag',
+          name: 'span',
           voidElement: false,
           attrs: {},
-          children: [{ type: "text", content: "Hi" }],
+          children: [{ type: 'text', content: 'Hi' }],
         },
-        { type: "text", content: " " },
-        { type: "comment", comment: " Another comment " },
-        { type: "text", content: " Something" },
+        { type: 'text', content: ' ' },
+        { type: 'comment', comment: ' Another comment ' },
+        { type: 'text', content: ' Something' },
       ],
-    }
+    },
   ])
 
   html = '<div>oh <strong>hello</strong> there! How are <span>you</span>?</div>'
@@ -750,7 +751,7 @@ test('parse', function (t) {
         children: [
           {
             content:
-              "\n      !function() {\n        var cookies = document.cookie ? document.cookie.split(';') : [];\n        //                |   this less than is triggering probems\n        for (var i = 0; i < cookies.length; i++) {\n          var splitted = cookies[i].split(\'=\');\n          var name = splitted[0];\n        }\n      }();\n      ",
+              "\n      !function() {\n        var cookies = document.cookie ? document.cookie.split(';') : [];\n        //                |   this less than is triggering probems\n        for (var i = 0; i < cookies.length; i++) {\n          var splitted = cookies[i].split('=');\n          var name = splitted[0];\n        }\n      }();\n      ",
             type: 'text',
           },
         ],
@@ -876,7 +877,7 @@ test('simple speed sanity check', function (t) {
       total += stepAverage
       waitCount = waitLoopSize
       // forcing a bit of a pause between tests
-      while (waitCount--) { }
+      while (waitCount--) {}
     }
   }
 
@@ -916,48 +917,57 @@ test('ReDoS vulnerability reported by Sam Sanoop of Snyk', function (t) {
 test('whitespace', function (t) {
   let html = '<div></div>\n'
   let parsed = HTML.parse(html)
-  t.deepEqual(parsed, [{
-    type: 'tag',
-    name: 'div',
-    attrs: {},
-    voidElement: false,
-    children: []
-  }], 'should not explode on trailing whitespace')
+  t.deepEqual(
+    parsed,
+    [
+      {
+        type: 'tag',
+        name: 'div',
+        attrs: {},
+        voidElement: false,
+        children: [],
+      },
+    ],
+    'should not explode on trailing whitespace'
+  )
 
   html = '<div>Hi</div>\n\n <span>There</span> \t <div> </div>'
   parsed = HTML.parse(html)
-  t.deepEqual(parsed, [{
-    type: 'tag',
-    name: 'div',
-    attrs: {},
-    voidElement: false,
-    children: [
-      { type: 'text', content: 'Hi' }
-    ]
-  }, {
-    type: 'text',
-    content: ' '
-  },
-  {
-    type: 'tag',
-    name: 'span',
-    attrs: {},
-    voidElement: false,
-    children: [
-      { type: 'text', content: 'There' }
-    ]
-  }, {
-    type: 'text',
-    content: ' '
-  }, {
-    type: 'tag',
-    name: 'div',
-    attrs: {},
-    voidElement: false,
-    children: [
-      { type: 'text', content: ' ' }
-    ]
-  }], 'should collapse whitespace')
+  t.deepEqual(
+    parsed,
+    [
+      {
+        type: 'tag',
+        name: 'div',
+        attrs: {},
+        voidElement: false,
+        children: [{ type: 'text', content: 'Hi' }],
+      },
+      {
+        type: 'text',
+        content: ' ',
+      },
+      {
+        type: 'tag',
+        name: 'span',
+        attrs: {},
+        voidElement: false,
+        children: [{ type: 'text', content: 'There' }],
+      },
+      {
+        type: 'text',
+        content: ' ',
+      },
+      {
+        type: 'tag',
+        name: 'div',
+        attrs: {},
+        voidElement: false,
+        children: [{ type: 'text', content: ' ' }],
+      },
+    ],
+    'should collapse whitespace'
+  )
   // See https://www.w3.org/TR/html4/struct/text.html#h-9.1
 
   t.end()
@@ -966,112 +976,124 @@ test('whitespace', function (t) {
 test('uppercase tags', function (t) {
   const html = '<0>click <Link>here</Link> for more</0>'
   const parsed = HTML.parse(html)
-  t.deepEqual(parsed, [
-    {
-      "type": "tag",
-      "name": "0",
-      "voidElement": false,
-      "attrs": {},
-      "children": [
-        {
-          "type": "text",
-          "content": "click "
-        },
-        {
-          "type": "tag",
-          "name": "Link",
-          "voidElement": false,
-          "attrs": {},
-          "children": [
-            {
-              "type": "text",
-              "content": "here"
-            }
-          ]
-        },
-        {
-          "type": "text",
-          "content": " for more"
-        }
-      ]
-    }
-  ], 'should handle uppercase tags correctly')
+  t.deepEqual(
+    parsed,
+    [
+      {
+        type: 'tag',
+        name: '0',
+        voidElement: false,
+        attrs: {},
+        children: [
+          {
+            type: 'text',
+            content: 'click ',
+          },
+          {
+            type: 'tag',
+            name: 'Link',
+            voidElement: false,
+            attrs: {},
+            children: [
+              {
+                type: 'text',
+                content: 'here',
+              },
+            ],
+          },
+          {
+            type: 'text',
+            content: ' for more',
+          },
+        ],
+      },
+    ],
+    'should handle uppercase tags correctly'
+  )
   t.end()
 })
 
 test('open tag in html string', function (t) {
   const html = '<0>hello under <10 <div>under 10</div> ok?</0>'
   const parsed = HTML.parse(html)
-  t.deepEqual(parsed, [
-    {
-      "type": "tag",
-      "name": "0",
-      "voidElement": false,
-      "attrs": {},
-      "children": [
-        {
-          "type": "text",
-          "content": "hello under <10 "
-        },
-        {
-          "type": "tag",
-          "name": "div",
-          "voidElement": false,
-          "attrs": {},
-          "children": [
-            {
-              "type": "text",
-              "content": "under 10"
-            }
-          ]
-        },
-        {
-          "type": "text",
-          "content": " ok?"
-        }
-      ]
-    }
-  ], 'should handle uppercase tags correctly')
+  t.deepEqual(
+    parsed,
+    [
+      {
+        type: 'tag',
+        name: '0',
+        voidElement: false,
+        attrs: {},
+        children: [
+          {
+            type: 'text',
+            content: 'hello under <10 ',
+          },
+          {
+            type: 'tag',
+            name: 'div',
+            voidElement: false,
+            attrs: {},
+            children: [
+              {
+                type: 'text',
+                content: 'under 10',
+              },
+            ],
+          },
+          {
+            type: 'text',
+            content: ' ok?',
+          },
+        ],
+      },
+    ],
+    'should handle uppercase tags correctly'
+  )
   t.end()
 })
 
-
 test('open tag in html string complex', function (t) {
-  const html = 'hello <italic>under ten</italic><10 this text after the sign should be rendered<bold>END</bold>'
+  const html =
+    'hello <italic>under ten</italic><10 this text after the sign should be rendered<bold>END</bold>'
   const parsed = HTML.parse(html)
-  t.deepEqual(parsed, [
-    {
-      "type": "text",
-      "content": "hello "
-    },
-    {
-      "type": "tag",
-      "name": "italic",
-      "voidElement": false,
-      "attrs": {},
-      "children": [
-        {
-          "type": "text",
-          "content": "under ten"
-        }
-      ]
-    },
-    {
-      "type": "text",
-      "content": "<10 this text after the sign should be rendered"
-    },
-    {
-      "type": "tag",
-      "name": "bold",
-      "voidElement": false,
-      "attrs": {},
-      "children": [
-        {
-          "type": "text",
-          "content": "END"
-        }
-      ]
-    }
-  ], 'should handle uppercase tags correctly')
+  t.deepEqual(
+    parsed,
+    [
+      {
+        type: 'text',
+        content: 'hello ',
+      },
+      {
+        type: 'tag',
+        name: 'italic',
+        voidElement: false,
+        attrs: {},
+        children: [
+          {
+            type: 'text',
+            content: 'under ten',
+          },
+        ],
+      },
+      {
+        type: 'text',
+        content: '<10 this text after the sign should be rendered',
+      },
+      {
+        type: 'tag',
+        name: 'bold',
+        voidElement: false,
+        attrs: {},
+        children: [
+          {
+            type: 'text',
+            content: 'END',
+          },
+        ],
+      },
+    ],
+    'should handle uppercase tags correctly'
+  )
   t.end()
 })

--- a/test/parse.js
+++ b/test/parse.js
@@ -1137,3 +1137,49 @@ test('lt inside quoted attribute values (#67 review)', function (t) {
   )
   t.end()
 })
+
+test('multiple literal < in text and CRLF attributes (#67 review round 2)', function (t) {
+  let html = '<div>1 < 2 < 3</div>'
+  t.deepEqual(
+    HTML.parse(html)[0].children,
+    [{ type: 'text', content: '1 < 2 < 3' }],
+    'should keep text with multiple literal < intact'
+  )
+  t.equal(HTML.stringify(HTML.parse(html)), html, 'should round-trip')
+
+  t.deepEqual(
+    HTML.parse('<span>x</span>1 < 2 < 3'),
+    [
+      {
+        type: 'tag',
+        name: 'span',
+        attrs: {},
+        voidElement: false,
+        children: [{ type: 'text', content: 'x' }],
+      },
+      { type: 'text', content: '1 < 2 < 3' },
+    ],
+    'should keep trailing text with multiple literal < intact'
+  )
+
+  t.deepEqual(
+    HTML.parse('<div><!-- c -->1 < 2</div>')[0].children,
+    [
+      { type: 'comment', comment: ' c ' },
+      { type: 'text', content: '1 < 2' },
+    ],
+    'should keep text with < after comments intact'
+  )
+
+  t.deepEqual(
+    HTML.parse('<div title="first\r\nsecond">Hello</div>')[0].attrs,
+    { title: 'first\r\nsecond' },
+    'should parse CRLF inside double-quoted attribute values'
+  )
+  t.deepEqual(
+    HTML.parse("<div title='first\r\nsecond'>x</div>")[0].attrs,
+    { title: 'first\r\nsecond' },
+    'should parse CRLF inside single-quoted attribute values'
+  )
+  t.end()
+})

--- a/test/parse.js
+++ b/test/parse.js
@@ -1097,3 +1097,43 @@ test('open tag in html string complex', function (t) {
   )
   t.end()
 })
+
+test('lt inside quoted attribute values (#67 review)', function (t) {
+  let html = '<div title="1 < 2">Hello</div>'
+  t.deepEqual(
+    HTML.parse(html),
+    [
+      {
+        type: 'tag',
+        name: 'div',
+        attrs: { title: '1 < 2' },
+        voidElement: false,
+        children: [{ type: 'text', content: 'Hello' }],
+      },
+    ],
+    'should keep < inside double-quoted attribute values'
+  )
+  t.equal(HTML.stringify(HTML.parse(html)), html, 'should round-trip')
+
+  html = "<div title='1 < 2'>Hello</div>"
+  t.deepEqual(
+    HTML.parse(html)[0].attrs,
+    { title: '1 < 2' },
+    'should keep < inside single-quoted attribute values'
+  )
+
+  html = '<div title="a > b < c">x</div>'
+  t.deepEqual(
+    HTML.parse(html)[0].attrs,
+    { title: 'a > b < c' },
+    'should keep mixed brackets inside quoted attribute values'
+  )
+
+  html = '<div><!-- a < b -->x</div>'
+  t.deepEqual(
+    HTML.parse(html)[0].children[0],
+    { type: 'comment', comment: ' a < b ' },
+    'should not corrupt comments containing <'
+  )
+  t.end()
+})

--- a/test/parse.js
+++ b/test/parse.js
@@ -1048,7 +1048,7 @@ test('open tag in html string', function (t) {
         ],
       },
     ],
-    'should handle uppercase tags correctly'
+    'should keep text containing < as text content'
   )
   t.end()
 })
@@ -1093,7 +1093,7 @@ test('open tag in html string complex', function (t) {
         ],
       },
     ],
-    'should handle uppercase tags correctly'
+    'should treat <10 followed by text as text, not as a tag'
   )
   t.end()
 })


### PR DESCRIPTION
This is the maintenance release announced in #65 (posted July 10, no objections in the 10-day window).

Branch protection requires one approving review, and direct pushes to master are blocked, so this PR bundles the whole release. **One approval from any collaborator with write access merges everything.** Happy to split it up if anyone prefers.

## What's inside

Merge commits for the long-standing community PRs (authorship preserved; GitHub will mark them merged automatically):

- #66 — LICENSE file (@monholm), closes #61
- #63 — multi-line attribute values (@steffanhalv), closes #62
- #51 / #52 — ship + improve the TypeScript declaration (@jiangfengming), closes #56
- #64 — text containing `<` no longer truncated, closes #59
- #53 — text after comment nodes no longer discarded (@tohosaku)

Plus one cleanup commit on top:

- replace `matchAll` with an exec loop (`matchAll` is ES2020; keeps the ES5 API compatibility the package always had)
- remove leftover debug logging from #64
- prettier pass on the touched files (repo's own config)
- README: 3.1.0 changelog entry + a note that ongoing development continues at the i18next org (see #65)

## Verification

- full test suite passes (58/58)
- golden-corpus diff against published 3.0.1 across 24 fixtures: 18 byte-identical, 6 diffs, each one an intended fix from the PRs above
- react-i18next (the largest dependent) test suite: 493/493 against this tree
